### PR TITLE
add catalog-info.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,26 +3,27 @@ jobs:
   build:
     working_directory: ~/go/src/github.com/Clever/go-redis-reservation
     docker:
-    - image: cimg/go:1.24
-    - image: redis@sha256:858b1677143e9f8455821881115e276f6177221de1c663d0abef9b2fda02d065
+      - image: cimg/go:1.24
+      - image: redis@sha256:858b1677143e9f8455821881115e276f6177221de1c663d0abef9b2fda02d065
     environment:
       GOPRIVATE: github.com/Clever/*
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
-    - run:
-        command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
-        name: Clone ci-scripts
-    - checkout
-    - setup_remote_docker
-    - run:
-        command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-        name: Set up CircleCI artifacts directories
-    - run:
-        command: git config --global "url.ssh://git@github.com/Clever".insteadOf "https://github.com/Clever"
-    - run:
-        name: Add github.com to known hosts
-        command: mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=' >> ~/.ssh/known_hosts
-    - run: make install_deps
-    - run: make test
-    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN; fi;
+      - run:
+          command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
+          name: Clone ci-scripts
+      - checkout
+      - setup_remote_docker
+      - run:
+          command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+          name: Set up CircleCI artifacts directories
+      - run:
+          command: git config --global "url.ssh://git@github.com/Clever".insteadOf "https://github.com/Clever"
+      - run:
+          name: Add github.com to known hosts
+          command: mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=' >> ~/.ssh/known_hosts
+      - run: make install_deps
+      - run: make test
+      - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN; fi;
+      - run: $HOME/ci-scripts/circleci/catalog-sync $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS go-redis-reservation utility

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: go-redis-reservation
+  description: Golang library for resource reservation using Redis
+  owner: unknown
+spec:
+  type: unknown
+  lifecycle: production
+  owner: unknown
+  system: Clever


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-7067


# Overview
We want track every single repo in backstage. Currently only repos with an `launch` directory i.e applications are tracked in backstage which this PR aims to change.

To track non applications repo we are adding a catalog-info.yaml file. In this PR I am adding that file via a microplane script so it 
- sets type to "unknown". In 2026 we will do an EWI to update all repos to have a type like "library", "cli", "docs", etc
- owner is determined via README or CODEOWNERS using best effort. In 2026 we will do an EWI to assign owners for unknowns and delete/archive repos that are not in use and have no owners
- description is same as the github repo description.

Note that some repos don't have a circle-ci project associated with them so those repos will get synced onced a week using `catalog-sync-all` worker instead of being synced on every merge.

## Testing
As long as CI is passing it is safe to merge these PRs but make sure to check that circleci is actually one of the checks because a misconfigured ci file ends up not getting reported instead of reporting an error

# Rollout
Infra to merge the PR once CI is passing and approved.
